### PR TITLE
Build fails on my ubuntu 20.10, missing wayland-protocols.

### DIFF
--- a/lg.sh
+++ b/lg.sh
@@ -26,7 +26,7 @@ FEDORA=`cat /etc/*release |  head -n 1 | cut -d ' ' -f 1`
 
 if [ "$DISTRO" == "Ubuntu" ] || [ "$DISTRO" == "Pop" ] || [ "$DISTRO" == "LinuxMint" ]
 	then
-apt-get install binutils-dev cmake fonts-freefont-ttf libsdl2-dev libsdl2-ttf-dev libspice-protocol-dev libfontconfig1-dev libx11-dev nettle-dev -y
+apt-get install binutils-dev cmake fonts-freefont-ttf libsdl2-dev libsdl2-ttf-dev libspice-protocol-dev libfontconfig1-dev libx11-dev nettle-dev  wayland-protocols -y
 elif [ "$DISTRO" == "ManjaroLinux" ]
 	then
 pacman -Syu binutils sdl2 sdl2_ttf libx11 nettle fontconfig cmake spice-protocol make pkg-config gcc gnu-free-fonts


### PR DESCRIPTION
Added this dep, build then completed.

```
Created symlink /etc/systemd/system/graphical.target.wants/lg_start.service → /etc/systemd/system/lg_start.service.
-- The C compiler identification is GNU 10.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test COMPILER_SUPPORTS_MARCH_NATIVE
-- Performing Test COMPILER_SUPPORTS_MARCH_NATIVE - Success
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
-- Checking for module 'sdl2'
--   Found sdl2, version 2.0.12
-- GMP libs: /usr/lib/x86_64-linux-gnu/libgmp.so /usr/lib/x86_64-linux-gnu/libgmpxx.so
-- Found GMP: /usr/include/x86_64-linux-gnu
-- Checking for modules 'spice-protocol;nettle;hogweed'
--   Found spice-protocol, version 0.14.1
--   Found nettle, version 3.6
--   Found hogweed, version 3.6
-- Checking for modules 'x11;xi;xfixes;xscrnsaver'
--   Found x11, version 1.6.12
--   Found xi, version 1.7.10
--   Found xfixes, version 5.0.3
--   Found xscrnsaver, version 1.2.3
-- Checking for module 'wayland-client'
--   Found wayland-client, version 1.18.0
-- Checking for module 'wayland-protocols>=1.15'
--   No package 'wayland-protocols' found
CMake Error at /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:493 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:677 (_pkg_check_modules_internal)
  displayservers/Wayland/CMakeLists.txt:30 (pkg_check_modules)
```